### PR TITLE
Inline setenv (fixes #6)

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,8 @@
+## Changes in next
+ - Add `setEnv` and `unsetEnv` to `System.Environment.Compat` (which were
+   ported from the `setenv` package). As a result, `base-compat` now depends
+   on `unix` on POSIX-like operating systems.
+
 ## Changes in 0.8.0.1
  - Retrospective version bump updating the changelog to reflect the changes
    made in 0.8.0

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# A compatibility layer for `base`
+# A compatibility layer for `base` [![Hackage version](https://img.shields.io/hackage/v/base-compat.svg?style=flat)](http://hackage.haskell.org/package/base-compat) [![Build Status](https://img.shields.io/travis/haskell-compat/base-compat.svg?style=flat)](https://travis-ci.org/haskell-compat/base-compat)
 ## Scope
 
 The scope of `base-compat` is to provide functions available in later versions
@@ -88,7 +88,6 @@ So far the following is covered.
    versions of `base`
  * `Text.Read.Compat.readMaybe`
  * `Text.Read.Compat.readEither`
- * `System.Environment.Compat.lookupEnv`
  * `Data.Monoid.Compat.<>`
  * Added `bool` function to `Data.Bool.Compat`
  * Added `isLeft` and `isRight` to `Data.Either.Compat`
@@ -103,6 +102,7 @@ So far the following is covered.
  * `calloc` and `callocBytes` functions to `Foreign.Marshal.Alloc.Compat`
  * `callocArray` and `callocArray0` functions to `Foreign.Marshal.Array.Compat`
  * Added `Data.List.Compat.scanl'`
+ * `lookupEnv`, `setEnv` and `unsetEnv` to `System.Environment.Compat`
 
 ## Supported versions of GHC/base
 

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -38,9 +38,10 @@ library
       -Wall
   build-depends:
       base == 4.*
-    , setenv
+  if !os(windows)
+      build-depends: unix
   ghc-options:
-    -fno-warn-duplicate-exports
+      -fno-warn-duplicate-exports
 
   hs-source-dirs:
       src

--- a/src/System/Environment/Compat.hs
+++ b/src/System/Environment/Compat.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, NoImplicitPrelude #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
 -- | Miscellaneous information about the system environment.
 module System.Environment.Compat (
   getArgs
@@ -15,15 +16,118 @@ module System.Environment.Compat (
 import           System.Environment
 
 #if !(MIN_VERSION_base(4,7,0))
-import           System.SetEnv
+import Prelude.Compat
+
+# ifdef mingw32_HOST_OS
+import           Control.Monad
+import           Foreign.C
+import           Foreign.Safe
+import           GHC.Windows
+# else
+import qualified System.Posix.Env as Posix
+# endif
+#endif
+
+#ifdef mingw32_HOST_OS
+# if defined(i386_HOST_ARCH)
+#  define WINDOWS_CCONV stdcall
+# elif defined(x86_64_HOST_ARCH)
+#  define WINDOWS_CCONV ccall
+# else
+#  error Unknown mingw32 arch
+# endif
+
+foreign import WINDOWS_CCONV unsafe "windows.h GetLastError"
+  c_GetLastError:: IO DWORD
+
+eRROR_ENVVAR_NOT_FOUND :: DWORD
+eRROR_ENVVAR_NOT_FOUND = 203
+
 #endif
 
 #if !(MIN_VERSION_base(4,6,0))
-import Prelude.Compat
 -- | Return the value of the environment variable @var@, or @Nothing@ if
 -- there is no such value.
 --
 -- For POSIX users, this is equivalent to 'System.Posix.Env.getEnv'.
 lookupEnv :: String -> IO (Maybe String)
 lookupEnv k = lookup k `fmap` getEnvironment
+#endif
+
+#if !(MIN_VERSION_base(4,7,0))
+-- | @setEnv name value@ sets the specified environment variable to @value@.
+--
+-- On Windows setting an environment variable to the /empty string/ removes
+-- that environment variable from the environment.  For the sake of
+-- compatibility we adopt that behavior.  In particular
+--
+-- @
+-- setEnv name \"\"
+-- @
+--
+-- has the same effect as
+--
+-- @
+-- `unsetEnv` name
+-- @
+--
+-- If you don't care about Windows support and want to set an environment
+-- variable to the empty string use @System.Posix.Env.setEnv@ from the @unix@
+-- package instead.
+--
+-- Throws `Control.Exception.IOException` if @name@ is the empty string or
+-- contains an equals sign.
+setEnv :: String -> String -> IO ()
+setEnv key value_
+  | null value = unsetEnv key
+  | otherwise  = setEnv_ key value
+  where
+    -- NOTE: Anything that follows NUL is ignored on both POSIX and Windows.
+    -- We still strip it manually so that the null check above succeds if a
+    -- value starts with NUL, and `unsetEnv` is called.  This is important for
+    -- two reasons.
+    --
+    --  * On POSIX setting an environment variable to the empty string does not
+    --    remove it.
+    --
+    --  * On Windows setting an environment variable to the empty string
+    --    removes that environment variable.  A subsequent call to
+    --    GetEnvironmentVariable will then return 0, but the calling thread's
+    --    last-error code will not be updated, and hence a call to GetLastError
+    --    may not return ERROR_ENVVAR_NOT_FOUND.  The failed lookup will then
+    --    result in a random error instead of the expected
+    --    `isDoesNotExistError` (this is at least true for Windows XP, SP 3).
+    --    Explicitly calling `unsetEnv` prevents this.
+    value = takeWhile (/= '\NUL') value_
+
+setEnv_ :: String -> String -> IO ()
+# ifdef mingw32_HOST_OS
+setEnv_ key value = withCWString key $ \k -> withCWString value $ \v -> do
+  success <- c_SetEnvironmentVariable k v
+  unless success (throwGetLastError "setEnv")
+
+foreign import WINDOWS_CCONV unsafe "windows.h SetEnvironmentVariableW"
+  c_SetEnvironmentVariable :: LPTSTR -> LPTSTR -> IO Bool
+# else
+setEnv_ k v = Posix.setEnv k v True
+# endif
+
+-- | @unsetEnv name@ removes the specified environment variable from the
+-- environment of the current process.
+--
+-- Throws `Control.Exception.IOException` if @name@ is the empty string or
+-- contains an equals sign.
+unsetEnv :: String -> IO ()
+# ifdef mingw32_HOST_OS
+unsetEnv key = withCWString key $ \k -> do
+  success <- c_SetEnvironmentVariable k nullPtr
+  unless success $ do
+    -- We consider unsetting an environment variable that does not exist not as
+    -- an error, hence we ignore eRROR_ENVVAR_NOT_FOUND.
+    err <- c_GetLastError
+    unless (err == eRROR_ENVVAR_NOT_FOUND) $ do
+      throwGetLastError "unsetEnv"
+# else
+unsetEnv = Posix.unsetEnv
+# endif
 #endif

--- a/src/System/Environment/Compat.hs
+++ b/src/System/Environment/Compat.hs
@@ -77,6 +77,9 @@ lookupEnv k = lookup k `fmap` getEnvironment
 --
 -- Throws `Control.Exception.IOException` if @name@ is the empty string or
 -- contains an equals sign.
+-- 
+-- Note that setting Unicode values may not work correctly on versions of GHC
+-- prior to 7.2.
 setEnv :: String -> String -> IO ()
 setEnv key value_
   | null value = unsetEnv key

--- a/test/System/Environment/CompatSpec.hs
+++ b/test/System/Environment/CompatSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module System.Environment.CompatSpec (main, spec) where
 
 import           Test.Hspec
@@ -91,10 +92,12 @@ spec = do
       setEnv "FOO\NULBAR" "foo"
       getEnv "FOO" `shouldReturn` "foo"
 
+#if __GLASGOW_HASKELL__ >= 702
     it "works for unicode" $ do
       unsetEnv "FOO"
       setEnv "FOO" "foo-\955-bar"
       getEnv "FOO" `shouldReturn` "foo-\955-bar"
+#endif
 
     it "works for arbitrary values" $
       property $ \v -> ('\NUL' `notElem` v && (not . null) v) ==> do

--- a/test/System/Environment/CompatSpec.hs
+++ b/test/System/Environment/CompatSpec.hs
@@ -1,9 +1,12 @@
 module System.Environment.CompatSpec (main, spec) where
 
 import           Test.Hspec
+import           Test.QuickCheck
 
-import           System.Environment.Compat
 import qualified Control.Exception as E
+import           GHC.IO.Exception (IOErrorType (InvalidArgument))
+import           System.Environment.Compat
+import           System.IO.Error
 
 main :: IO ()
 main = hspec spec
@@ -32,3 +35,83 @@ spec = do
     it "returns Nothing if specified environment variable is not set" $ do
       withoutEnv "FOOBAR" $ do
         lookupEnv "FOOBAR" `shouldReturn` Nothing
+
+  describe "unsetEnv" $ do
+    it "removes specified environment variable" $ do
+      setEnv "FOO" "foo"
+      unsetEnv "FOO"
+      getEnv "FOO" `shouldThrow` isDoesNotExistError
+
+    it "does nothing if specified environment variable is not set" $ do
+      unsetEnv "BAR"
+      unsetEnv "BAR"
+      getEnv "BAR" `shouldThrow` isDoesNotExistError
+
+    it "throws an exception if key is the empty string" $ do
+      unsetEnv "" `shouldThrow` (== InvalidArgument) . ioeGetErrorType
+
+    it "throws an exception if key contains '='" $ do
+      unsetEnv "some=key" `shouldThrow` (== InvalidArgument) . ioeGetErrorType
+
+    it "works for arbitrary keys" $
+      property $ \k -> ('\NUL' `notElem` k && '=' `notElem` k && (not . null) k) ==> do
+        setEnv k "foo"
+        unsetEnv k
+        getEnv k `shouldThrow` isDoesNotExistError
+
+  describe "setEnv" $ do
+    it "sets specified environment variable to given value" $ do
+      unsetEnv "FOO"
+      setEnv "FOO" "foo"
+      getEnv "FOO" `shouldReturn` "foo"
+
+    it "resets specified environment variable, if it is already set" $ do
+      unsetEnv "FOO"
+      setEnv "FOO" "foo"
+      setEnv "FOO" "bar"
+      getEnv "FOO" `shouldReturn` "bar"
+
+    it "removes specified environment variable when value is the empty string" $ do
+      setEnv "FOO" "foo"
+      setEnv "FOO" ""
+      getEnv "FOO" `shouldThrow` isDoesNotExistError
+
+    it "removes specified environment variable when first character of value is NUL" $ do
+      setEnv "FOO" "foo"
+      setEnv "FOO" "\NULfoo"
+      getEnv "FOO" `shouldThrow` isDoesNotExistError
+
+    it "truncates value at NUL character" $ do
+      unsetEnv "FOO"
+      setEnv "FOO" "foo\NULbar"
+      getEnv "FOO" `shouldReturn` "foo"
+
+    it "truncates key at NUL character" $ do
+      unsetEnv "FOO"
+      setEnv "FOO\NULBAR" "foo"
+      getEnv "FOO" `shouldReturn` "foo"
+
+    it "works for unicode" $ do
+      unsetEnv "FOO"
+      setEnv "FOO" "foo-\955-bar"
+      getEnv "FOO" `shouldReturn` "foo-\955-bar"
+
+    it "works for arbitrary values" $
+      property $ \v -> ('\NUL' `notElem` v && (not . null) v) ==> do
+        setEnv "FOO" v
+        getEnv "FOO" `shouldReturn` v
+
+    it "works for unicode keys" $ do
+      setEnv "foo-\955-bar" "foo"
+      getEnv "foo-\955-bar" `shouldReturn` "foo"
+
+    it "throws an exception if key is the empty string" $ do
+      setEnv "" "foo" `shouldThrow` (== InvalidArgument) . ioeGetErrorType
+
+    it "throws an exception if key contains '='" $ do
+      setEnv "some=key" "foo" `shouldThrow` (== InvalidArgument) . ioeGetErrorType
+
+    it "works for arbitrary keys" $
+      property $ \k -> ('\NUL' `notElem` k && '=' `notElem` k && (not . null) k) ==> do
+        setEnv k "foo"
+        getEnv k `shouldReturn` "foo"


### PR DESCRIPTION
My attempt at bringing in `setEnv` and `unsetEnv` from the [`setenv`](https://github.com/sol/setenv) package. The only major hiccup I experienced was that using `setEnv` to set a Unicode value doesn't appear to work correctly on GHC 7.0, likely due to [Unicode support being improved](https://downloads.haskell.org/~ghc/7.2.1/docs/html/users_guide/release-7-2-1.html#id567233) starting with GHC 7.2. To get around this, I disabled that particular test on GHCs prior to 7.2, and I added a warning to the documentation of `setEnv`.