### PR TITLE
Functions added in base-4.4, 4.5, and 4.6

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,4 +1,5 @@
 ## Changes in next
+ - Backport `forkFinally` to `Control.Concurrent.Compat`
  - Backport `modifyIORef'`, `atomicModifyIORef'` and `atomicWriteIORef` to
    `Data.IORef.Compat`
  - Backport `modifySTRef'` to `Data.STRef.Compat`

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in next
+ - Backport `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
+
 ## Changes in 0.8.2
  - Backport `bitDefault`, `testBitDefault`, and `popCountDefault` in
    `Data.Bits.Compat` to all versions of `base`

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,9 +1,12 @@
 ## Changes in next
+ - Backport `.Unsafe.Compat` modules (for `Control.Monad.ST`,
+   `Control.Monad.ST.Lazy`, `Foreign.ForeignPtr`, and `Foreign.Marshal`)
  - Backport `forkFinally` to `Control.Concurrent.Compat`
  - Backport `modifyIORef'`, `atomicModifyIORef'` and `atomicWriteIORef` to
    `Data.IORef.Compat`
  - Backport `modifySTRef'` to `Data.STRef.Compat`
- - Export `String`, `lines`, `words`, `unlines`, and `unwords` from `Data.String.Compat`
+ - Export `String`, `lines`, `words`, `unlines`, and `unwords` to
+   `Data.String.Compat`
  - Backport `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
 
 ## Changes in 0.8.2

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -3,6 +3,7 @@
  - Backport `modifyIORef'`, `atomicModifyIORef'` and `atomicWriteIORef` to
    `Data.IORef.Compat`
  - Backport `modifySTRef'` to `Data.STRef.Compat`
+ - Export `String`, `lines`, `words`, `unlines`, and `unwords` from `Data.String.Compat`
  - Backport `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
 
 ## Changes in 0.8.2

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,4 +1,5 @@
 ## Changes in next
+ - Backport `Foreign.ForeignPtr.Safe` and `Foreign.Marshal.Safe`
  - Backport `.Unsafe.Compat` modules (for `Control.Monad.ST`,
    `Control.Monad.ST.Lazy`, `Foreign.ForeignPtr`, and `Foreign.Marshal`)
  - Backport `forkFinally` to `Control.Concurrent.Compat`

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,4 +1,6 @@
 ## Changes in next
+ - Backport `modifyIORef'`, `atomicModifyIORef'` and `atomicWriteIORef` to
+   `Data.IORef.Compat`
  - Backport `modifySTRef'` to `Data.STRef.Compat`
  - Backport `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
 

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,4 +1,5 @@
 ## Changes in next
+ - Backport `modifySTRef'` to `Data.STRef.Compat`
  - Backport `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
 
 ## Changes in 0.8.2

--- a/README.markdown
+++ b/README.markdown
@@ -109,6 +109,7 @@ So far the following is covered.
  * Added `Data.List.Compat.scanl'`
  * `showFFloatAlt` and `showGFloatAlt` to `Numeric.Compat`
  * `lookupEnv`, `setEnv` and `unsetEnv` to `System.Environment.Compat`
+ * `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
 
 ## Supported versions of GHC/base
 

--- a/README.markdown
+++ b/README.markdown
@@ -93,6 +93,7 @@ So far the following is covered.
  * Added `toIntegralSized` to `Data.Bits.Compat` (if using `base-4.7`)
  * Added `bool` function to `Data.Bool.Compat`
  * Added `isLeft` and `isRight` to `Data.Either.Compat`
+ * Added `forkFinally` to `Control.Concurrent.Compat`
  * Added `withMVarMasked` function to `Control.Concurrent.MVar.Compat`
  * Added `(<$!>)` function to `Control.Monad.Compat`
  * Added `($>)` and `void` functions to `Data.Functor.Compat`

--- a/README.markdown
+++ b/README.markdown
@@ -98,6 +98,7 @@ So far the following is covered.
  * Added `($>)` and `void` functions to `Data.Functor.Compat`
  * `(&)` function to `Data.Function.Compat`
  * `($>)` and `void` functions to `Data.Functor.Compat`
+ * `modifyIORef'`, `atomicModifyIORef'` and `atomicWriteIORef` to `Data.IORef.Compat`
  * `dropWhileEnd`, `isSubsequenceOf`, `sortOn`, and `uncons` functions to `Data.List.Compat`
  * Correct versions of `nub`, `nubBy`, `union`, and `unionBy` to `Data.List.Compat`
  * `modifySTRef'` to `Data.STRef.Compat`

--- a/README.markdown
+++ b/README.markdown
@@ -103,6 +103,7 @@ So far the following is covered.
  * `dropWhileEnd`, `isSubsequenceOf`, `sortOn`, and `uncons` functions to `Data.List.Compat`
  * Correct versions of `nub`, `nubBy`, `union`, and `unionBy` to `Data.List.Compat`
  * `modifySTRef'` to `Data.STRef.Compat`
+ * `String`, `lines`, `words`, `unlines`, and `unwords` to `Data.String.Compat`
  * `makeVersion` function to `Data.Version.Compat`
  * `traceId`, `traceShowId`, `traceM`, and `traceShowM` functions to `Debug.Trace.Compat`
  * `byteSwap16`, `byteSwap32`, and `byteSwap64` to `Data.Word.Compat`

--- a/README.markdown
+++ b/README.markdown
@@ -100,6 +100,7 @@ So far the following is covered.
  * `($>)` and `void` functions to `Data.Functor.Compat`
  * `dropWhileEnd`, `isSubsequenceOf`, `sortOn`, and `uncons` functions to `Data.List.Compat`
  * Correct versions of `nub`, `nubBy`, `union`, and `unionBy` to `Data.List.Compat`
+ * `modifySTRef'` to `Data.STRef.Compat`
  * `makeVersion` function to `Data.Version.Compat`
  * `traceId`, `traceShowId`, `traceM`, and `traceShowM` functions to `Debug.Trace.Compat`
  * `byteSwap16`, `byteSwap32`, and `byteSwap64` to `Data.Word.Compat`

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -69,6 +69,7 @@ library
       Prelude.Compat
       System.Environment.Compat
       System.Exit.Compat
+      System.IO.Unsafe.Compat
       Text.Read.Compat
 
 test-suite spec

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -60,6 +60,7 @@ library
       Data.List.Compat
       Data.Monoid.Compat
       Data.STRef.Compat
+      Data.String.Compat
       Data.Version.Compat
       Data.Word.Compat
       Debug.Trace.Compat

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -50,6 +50,8 @@ library
       Control.Concurrent.Compat
       Control.Concurrent.MVar.Compat
       Control.Monad.Compat
+      Control.Monad.ST.Lazy.Unsafe.Compat
+      Control.Monad.ST.Unsafe.Compat
       Data.Bits.Compat
       Data.Bool.Compat
       Data.Either.Compat
@@ -65,9 +67,11 @@ library
       Data.Word.Compat
       Debug.Trace.Compat
       Foreign.Compat
+      Foreign.ForeignPtr.Unsafe.Compat
       Foreign.Marshal.Alloc.Compat
       Foreign.Marshal.Array.Compat
       Foreign.Marshal.Compat
+      Foreign.Marshal.Unsafe.Compat
       Foreign.Marshal.Utils.Compat
       Numeric.Compat
       Prelude.Compat

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -57,6 +57,7 @@ library
       Data.Functor.Compat
       Data.List.Compat
       Data.Monoid.Compat
+      Data.STRef.Compat
       Data.Version.Compat
       Data.Word.Compat
       Debug.Trace.Compat
@@ -90,6 +91,7 @@ test-suite spec
       Data.Functor.CompatSpec
       Data.List.CompatSpec
       Data.Monoid.CompatSpec
+      Data.STRef.CompatSpec
       Data.Version.CompatSpec
       Data.Word.CompatSpec
       Foreign.Marshal.Alloc.CompatSpec

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -67,10 +67,12 @@ library
       Data.Word.Compat
       Debug.Trace.Compat
       Foreign.Compat
+      Foreign.ForeignPtr.Safe.Compat
       Foreign.ForeignPtr.Unsafe.Compat
       Foreign.Marshal.Alloc.Compat
       Foreign.Marshal.Array.Compat
       Foreign.Marshal.Compat
+      Foreign.Marshal.Safe.Compat
       Foreign.Marshal.Unsafe.Compat
       Foreign.Marshal.Utils.Compat
       Numeric.Compat

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -47,6 +47,7 @@ library
       src
 
   exposed-modules:
+      Control.Concurrent.Compat
       Control.Concurrent.MVar.Compat
       Control.Monad.Compat
       Data.Bits.Compat

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -55,6 +55,7 @@ library
       Data.Foldable.Compat
       Data.Function.Compat
       Data.Functor.Compat
+      Data.IORef.Compat
       Data.List.Compat
       Data.Monoid.Compat
       Data.STRef.Compat
@@ -89,6 +90,7 @@ test-suite spec
       Data.Either.CompatSpec
       Data.Function.CompatSpec
       Data.Functor.CompatSpec
+      Data.IORef.CompatSpec
       Data.List.CompatSpec
       Data.Monoid.CompatSpec
       Data.STRef.CompatSpec

--- a/src/Control/Concurrent/Compat.hs
+++ b/src/Control/Concurrent/Compat.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Control.Concurrent.Compat (
+  module Base
+, forkFinally
+) where
+
+import Control.Concurrent as Base
+
+#if !(MIN_VERSION_base(4,6,0))
+import Control.Exception
+import Prelude
+
+-- | fork a thread and call the supplied function when the thread is about
+-- to terminate, with an exception or a returned value.  The function is
+-- called with asynchronous exceptions masked.
+--
+-- > forkFinally action and_then =
+-- >   mask $ \restore ->
+-- >     forkIO $ try (restore action) >>= and_then
+--
+-- This function is useful for informing the parent when a child
+-- terminates, for example.
+--
+-- /Since: 4.6.0.0/
+forkFinally :: IO a -> (Either SomeException a -> IO ()) -> IO ThreadId
+forkFinally action and_then =
+  mask $ \restore ->
+    forkIO $ try (restore action) >>= and_then
+#endif

--- a/src/Control/Monad/ST/Lazy/Unsafe/Compat.hs
+++ b/src/Control/Monad/ST/Lazy/Unsafe/Compat.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Control.Monad.ST.Lazy.Unsafe.Compat (
+  -- * Unsafe operations
+  unsafeInterleaveST
+, unsafeIOToST
+) where
+
+import Control.Monad.ST.Lazy (unsafeInterleaveST, unsafeIOToST)

--- a/src/Control/Monad/ST/Lazy/Unsafe/Compat.hs
+++ b/src/Control/Monad/ST/Lazy/Unsafe/Compat.hs
@@ -5,4 +5,8 @@ module Control.Monad.ST.Lazy.Unsafe.Compat (
 , unsafeIOToST
 ) where
 
+#if MIN_VERSION_base(4,6,0)
+import Control.Monad.ST.Lazy.Unsafe (unsafeInterleaveST, unsafeIOToST)
+#else
 import Control.Monad.ST.Lazy (unsafeInterleaveST, unsafeIOToST)
+#endif

--- a/src/Control/Monad/ST/Unsafe/Compat.hs
+++ b/src/Control/Monad/ST/Unsafe/Compat.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Control.Monad.ST.Unsafe.Compat (
+  -- * Unsafe operations
+  unsafeInterleaveST
+, unsafeIOToST
+, unsafeSTToIO
+) where
+
+import Control.Monad.ST (unsafeInterleaveST, unsafeIOToST, unsafeSTToIO)

--- a/src/Control/Monad/ST/Unsafe/Compat.hs
+++ b/src/Control/Monad/ST/Unsafe/Compat.hs
@@ -6,4 +6,8 @@ module Control.Monad.ST.Unsafe.Compat (
 , unsafeSTToIO
 ) where
 
+#if MIN_VERSION_base(4,6,0)
+import Control.Monad.ST.Unsafe (unsafeInterleaveST, unsafeIOToST, unsafeSTToIO)
+#else
 import Control.Monad.ST (unsafeInterleaveST, unsafeIOToST, unsafeSTToIO)
+#endif

--- a/src/Data/IORef/Compat.hs
+++ b/src/Data/IORef/Compat.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Data.IORef.Compat (
+  module Base
+, modifyIORef'
+, atomicModifyIORef'
+, atomicWriteIORef
+) where
+
+import Data.IORef as Base
+
+#if !(MIN_VERSION_base(4,6,0))
+import Prelude
+
+-- |Strict version of 'modifyIORef'
+--
+-- /Since: 4.6.0.0/
+modifyIORef' :: IORef a -> (a -> a) -> IO ()
+modifyIORef' ref f = do
+    x <- readIORef ref
+    let x' = f x
+    x' `seq` writeIORef ref x'
+
+-- | Strict version of 'atomicModifyIORef'.  This forces both the value stored
+-- in the 'IORef' as well as the value returned.
+--
+-- /Since: 4.6.0.0/
+atomicModifyIORef' :: IORef a -> (a -> (a,b)) -> IO b
+atomicModifyIORef' ref f = do
+    b <- atomicModifyIORef ref $ \a ->
+            case f a of
+                v@(a',_) -> a' `seq` v
+    b `seq` return b
+
+-- | Variant of 'writeIORef' with the \"barrier to reordering\" property that
+-- 'atomicModifyIORef' has.
+--
+-- /Since: 4.6.0.0/
+atomicWriteIORef :: IORef a -> a -> IO ()
+atomicWriteIORef ref a = do
+    x <- atomicModifyIORef ref (\_ -> (a, ()))
+    x `seq` return ()
+#endif

--- a/src/Data/STRef/Compat.hs
+++ b/src/Data/STRef/Compat.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Data.STRef.Compat (
+  module Base
+, modifySTRef'
+) where
+
+import Data.STRef as Base
+
+#if !(MIN_VERSION_base(4,6,0))
+import Control.Monad.ST (ST)
+import Prelude (seq)
+
+-- | Strict version of 'modifySTRef'
+--
+-- /Since: 4.6.0.0/
+modifySTRef' :: STRef s a -> (a -> a) -> ST s ()
+modifySTRef' ref f = do
+    x <- readSTRef ref
+    let x' = f x
+    x' `seq` writeSTRef ref x'
+#endif

--- a/src/Data/String/Compat.hs
+++ b/src/Data/String/Compat.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Data.String.Compat (
+  module Base
+, String
+, lines
+, words
+, unlines
+, unwords
+) where
+
+import Data.String as Base
+
+#if !(MIN_VERSION_base(4,4,0))
+import Prelude (String, lines, words, unlines, unwords)
+#endif

--- a/src/Foreign/ForeignPtr/Safe/Compat.hs
+++ b/src/Foreign/ForeignPtr/Safe/Compat.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Foreign.ForeignPtr.Safe.Compat (
+        -- * Finalised data pointers
+          ForeignPtr
+        , FinalizerPtr
+#if defined(__HUGS__) || defined(__GLASGOW_HASKELL__)
+        , FinalizerEnvPtr
+#endif
+        -- ** Basic operations
+        , newForeignPtr
+        , newForeignPtr_
+        , addForeignPtrFinalizer
+#if defined(__HUGS__) || defined(__GLASGOW_HASKELL__)
+        , newForeignPtrEnv
+        , addForeignPtrFinalizerEnv
+#endif
+        , withForeignPtr
+
+#ifdef __GLASGOW_HASKELL__
+        , finalizeForeignPtr
+#endif
+
+        -- ** Low-level operations
+        , touchForeignPtr
+        , castForeignPtr
+
+        -- ** Allocating managed memory
+        , mallocForeignPtr
+        , mallocForeignPtrBytes
+        , mallocForeignPtrArray
+        , mallocForeignPtrArray0
+    ) where
+
+import Foreign.ForeignPtr

--- a/src/Foreign/ForeignPtr/Unsafe/Compat.hs
+++ b/src/Foreign/ForeignPtr/Unsafe/Compat.hs
@@ -4,4 +4,8 @@ module Foreign.ForeignPtr.Unsafe.Compat (
   unsafeForeignPtrToPtr
 ) where
 
+#if MIN_VERSION_base(4,6,0)
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
+#else
 import Foreign.ForeignPtr (unsafeForeignPtrToPtr)
+#endif

--- a/src/Foreign/ForeignPtr/Unsafe/Compat.hs
+++ b/src/Foreign/ForeignPtr/Unsafe/Compat.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Foreign.ForeignPtr.Unsafe.Compat (
+  -- ** Unsafe low-level operations
+  unsafeForeignPtrToPtr
+) where
+
+import Foreign.ForeignPtr (unsafeForeignPtrToPtr)

--- a/src/Foreign/Marshal/Safe/Compat.hs
+++ b/src/Foreign/Marshal/Safe/Compat.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Foreign.Marshal.Safe.Compat (
+         -- | The module "Foreign.Marshal.Safe" re-exports the other modules in the
+         -- @Foreign.Marshal@ hierarchy:
+          module Foreign.Marshal.Alloc
+        , module Foreign.Marshal.Array
+        , module Foreign.Marshal.Error
+        , module Foreign.Marshal.Pool
+        , module Foreign.Marshal.Utils
+        ) where
+
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Array
+import Foreign.Marshal.Error
+import Foreign.Marshal.Pool
+import Foreign.Marshal.Utils

--- a/src/Foreign/Marshal/Unsafe/Compat.hs
+++ b/src/Foreign/Marshal/Unsafe/Compat.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Foreign.Marshal.Unsafe.Compat (
+  -- * Unsafe functions
+  unsafeLocalState
+) where
+
+import Foreign.Marshal (unsafeLocalState)

--- a/src/Foreign/Marshal/Unsafe/Compat.hs
+++ b/src/Foreign/Marshal/Unsafe/Compat.hs
@@ -4,4 +4,8 @@ module Foreign.Marshal.Unsafe.Compat (
   unsafeLocalState
 ) where
 
+#if MIN_VERSION_base(4,6,0)
+import Foreign.Marshal.Unsafe (unsafeLocalState)
+#else
 import Foreign.Marshal (unsafeLocalState)
+#endif

--- a/src/System/IO/Unsafe/Compat.hs
+++ b/src/System/IO/Unsafe/Compat.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+module System.IO.Unsafe.Compat (
+  module Base
+, unsafeFixIO
+, unsafeDupablePerformIO
+) where
+
+import System.IO.Unsafe as Base
+
+#if !(MIN_VERSION_base(4,5,0))
+import Control.Exception
+import Data.IORef
+import GHC.Base
+import GHC.IO
+
+-- | A slightly faster version of `System.IO.fixIO` that may not be
+-- safe to use with multiple threads.  The unsafety arises when used
+-- like this:
+--
+-- >  unsafeFixIO $ \r -> do
+-- >     forkIO (print r)
+-- >     return (...)
+--
+-- In this case, the child thread will receive a @NonTermination@
+-- exception instead of waiting for the value of @r@ to be computed.
+--
+-- @since 4.5.0.0
+unsafeFixIO :: (a -> IO a) -> IO a
+unsafeFixIO k = do
+  ref <- newIORef (throw NonTermination)
+  ans <- unsafeDupableInterleaveIO (readIORef ref)
+  result <- k ans
+  writeIORef ref result
+  return result
+#endif

--- a/src/System/IO/Unsafe/Compat.hs
+++ b/src/System/IO/Unsafe/Compat.hs
@@ -25,7 +25,7 @@ import GHC.IO
 -- In this case, the child thread will receive a @NonTermination@
 -- exception instead of waiting for the value of @r@ to be computed.
 --
--- @since 4.5.0.0
+-- /Since: 4.5.0.0/
 unsafeFixIO :: (a -> IO a) -> IO a
 unsafeFixIO k = do
   ref <- newIORef (throw NonTermination)

--- a/src/System/IO/Unsafe/Compat.hs
+++ b/src/System/IO/Unsafe/Compat.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP, NoImplicitPrelude #-}
-{-# LANGUAGE MagicHash, UnboxedTuples #-}
 module System.IO.Unsafe.Compat (
   module Base
 , unsafeFixIO

--- a/test/Data/IORef/CompatSpec.hs
+++ b/test/Data/IORef/CompatSpec.hs
@@ -1,0 +1,22 @@
+module Data.IORef.CompatSpec (main, spec) where
+
+import           Test.Hspec
+
+import           Control.Monad
+import           Data.IORef.Compat
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "modifyIORef'" $
+    it "mutates the contents of an IORef strictly" $ do
+      ref <- newIORef 0
+      replicateM_ 1000000 $ modifyIORef' ref (+1)
+      readIORef ref `shouldReturn` (1000000 :: Int)
+  describe "atomicModifyIORef'" $
+    it "atomically modifies the contents of an IORef strictly" $ do
+      ref <- newIORef 0
+      replicateM_ 1000000 . atomicModifyIORef' ref $ \n -> (n+1, ())
+      readIORef ref `shouldReturn` (1000000 :: Int)

--- a/test/Data/STRef/CompatSpec.hs
+++ b/test/Data/STRef/CompatSpec.hs
@@ -1,0 +1,19 @@
+module Data.STRef.CompatSpec (main, spec) where
+
+import           Test.Hspec
+
+import           Control.Monad
+import           Control.Monad.ST
+import           Data.STRef.Compat
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "modifySTRef'" $
+    it "should mutate the contents of an STRef strictly" $
+      shouldBe (1000000 :: Int) $ runST $ do
+        ref <- newSTRef 0
+        replicateM_ 1000000 $ modifySTRef' ref (+1)
+        readSTRef ref


### PR DESCRIPTION
Some more functions and modules which were added in old versions of `base`. Specifically:

* Backport `Foreign.ForeignPtr.Safe` and `Foreign.Marshal.Safe`
* Backport `.Unsafe.Compat` modules (for `Control.Monad.ST`, `Control.Monad.ST.Lazy`, `Foreign.ForeignPtr`, and `Foreign.Marshal`)
* Backport `forkFinally` to `Control.Concurrent.Compat`
* Backport `modifyIORef'`, `atomicModifyIORef'` and `atomicWriteIORef` to `Data.IORef.Compat`
* Backport `modifySTRef'` to `Data.STRef.Compat`
* Export `String`, `lines`, `words`, `unlines`, and `unwords` from `Data.String.Compat`
* Backport `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`