### PR TITLE
Added Data.Proxy.Compat

### DIFF
--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -61,6 +61,7 @@ library
       Data.IORef.Compat
       Data.List.Compat
       Data.Monoid.Compat
+      Data.Proxy.Compat
       Data.STRef.Compat
       Data.String.Compat
       Data.Version.Compat
@@ -101,6 +102,7 @@ test-suite spec
       Data.IORef.CompatSpec
       Data.List.CompatSpec
       Data.Monoid.CompatSpec
+      Data.Proxy.CompatSpec
       Data.STRef.CompatSpec
       Data.Version.CompatSpec
       Data.Word.CompatSpec

--- a/src/Data/Proxy/Compat.hs
+++ b/src/Data/Proxy/Compat.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Data.Proxy.Compat (
+  Proxy         (..)
+, asProxyTypeOf
+) where
+
+#if MIN_VERSION_base(4,7,0)
+import Data.Proxy(Proxy(..), asProxyTypeOf)
+#else
+
+import GHC.Base
+import GHC.Show
+import GHC.Read
+import GHC.Enum
+import GHC.Arr
+
+-- | A concrete, poly-kinded proxy type
+data Proxy t = Proxy
+
+-- We omit KProxy for older GHC versions.
+--data KProxy (t :: *) = KProxy
+
+instance Eq (Proxy s) where
+  _ == _ = True
+
+instance Ord (Proxy s) where
+  compare _ _ = EQ
+
+instance Show (Proxy s) where
+  showsPrec _ _ = showString "Proxy"
+
+instance Read (Proxy s) where
+  readsPrec d = readParen (d > 10) (\r -> [(Proxy, s) | ("Proxy",s) <- lex r ])
+
+instance Enum (Proxy s) where
+    succ _               = error "Proxy.succ"
+    pred _               = error "Proxy.pred"
+    fromEnum _           = 0
+    toEnum 0             = Proxy
+    toEnum _             = error "Proxy.toEnum: 0 expected"
+    enumFrom _           = [Proxy]
+    enumFromThen _ _     = [Proxy]
+    enumFromThenTo _ _ _ = [Proxy]
+    enumFromTo _ _       = [Proxy]
+
+instance Ix (Proxy s) where
+    range _           = [Proxy]
+    index _ _         = 0
+    inRange _ _       = True
+    rangeSize _       = 1
+    unsafeIndex _ _   = 0
+    unsafeRangeSize _ = 1
+
+instance Bounded (Proxy s) where
+    minBound = Proxy
+    maxBound = Proxy
+
+instance Functor Proxy where
+    fmap _ _ = Proxy
+    {-# INLINE fmap #-}
+
+instance Monad Proxy where
+    return _ = Proxy
+    {-# INLINE return #-}
+    _ >>= _ = Proxy
+    {-# INLINE (>>=) #-}
+
+-- | 'asProxyTypeOf' is a type-restricted version of 'const'.
+-- It is usually used as an infix operator, and its typing forces its first
+-- argument (which is usually overloaded) to have the same type as the tag
+-- of the second.
+asProxyTypeOf :: a -> Proxy a -> a
+asProxyTypeOf = const
+{-# INLINE asProxyTypeOf #-}
+#endif
+

--- a/test/Data/Proxy/CompatSpec.hs
+++ b/test/Data/Proxy/CompatSpec.hs
@@ -1,0 +1,32 @@
+module Data.Proxy.CompatSpec (main, spec) where
+
+import           Test.Hspec
+
+import           Data.Proxy.Compat
+
+class TestClass a where
+  whoami :: Proxy a -> String
+
+instance TestClass Bool where
+  whoami _ = "booly"
+
+instance TestClass Ordering where
+  whoami _ = "orderly"
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Proxy" $ do
+    it "shows correct instance for explicitly given Proxy Bool type" $ do
+      whoami (Proxy :: Proxy Bool)     `shouldBe` "booly"
+    it "shows correct instance for explicitly given Proxy Ordering type" $ do
+      whoami (Proxy :: Proxy Ordering) `shouldBe` "orderly"
+    describe "asProxyTypeOf" $ do
+    it "check that asProxyTypeOf type forces to pick correct instance of Bounded" $ do
+      (minBound `asProxyTypeOf` pBool) `shouldBe` False
+      (maxBound `asProxyTypeOf` pBool) `shouldBe` True
+  where
+    pBool = Proxy :: Proxy Bool
+


### PR DESCRIPTION
`Data.Proxy` is used frequently, mostly for the `Proxy` type alone, not newer (and poly-kinded) `KProxy`.

So I would like you to pull `Data.Proxy` without poly-kinded `KProxy` type for backwards compatibility.