### PR TITLE
Don't depend on the unix package on HaLVM

### DIFF
--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -50,7 +50,7 @@ library
       -Wall
   build-depends:
       base >= 4.3 && < 5
-  if !os(windows)
+  if !os(windows) && !os(halvm)
       build-depends: unix
   ghc-options:
       -fno-warn-duplicate-exports

--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -1,5 +1,5 @@
 name:             base-compat
-version:          0.9.0
+version:          0.9.0.1
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2016 Simon Hengel,


### PR DESCRIPTION
Small cabal file tweak to make base-compat work with the HaLVM.
