### PR TITLE
Disallow unix for HaLVM builds

### DIFF
--- a/base-compat.cabal
+++ b/base-compat.cabal
@@ -50,7 +50,7 @@ library
       -Wall
   build-depends:
       base >= 4.3 && < 5
-  if !os(windows)
+  if !os(windows) && !os(halvm)
       build-depends: unix
   ghc-options:
       -fno-warn-duplicate-exports


### PR DESCRIPTION
Unikernels created by `HaLVM` cannot yet depend on `unix`. `HaLVMOS` was added in 2011 to `Cabal`, so this should be a backwards compatible change, until pre-7.6.3.

https://github.com/haskell/cabal/commit/0a1b4810c55c90de5ef613944ee6ea09a3b521c3