### PR TITLE
Reexport (Data.Semigroup.<>) from Data.Monoid.Compat more often

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,7 +170,7 @@ script:
      cd ..;
 
      cd check/;
-     wget https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.1/typediff;
+     wget https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.2/typediff;
      chmod +x typediff;
      cabal configure ${TEST} -v2 ${CABALFLAGS};
      cabal build;

--- a/base-compat-batteries/CHANGES.markdown
+++ b/base-compat-batteries/CHANGES.markdown
@@ -1,6 +1,7 @@
 ## Changes in 0.10.1 [2018.04.xx]
-- Add `Data.List.NonEmpty.Compat`
-- Tighten lower bounds of compat package dependencies
+- Add `Data.List.NonEmpty.Compat`.
+- Reexport `(Data.Semigroup.<>)` from `Data.Monoid.Compat`.
+- Tighten lower bounds of compat package dependencies.
 
 ## Changes in 0.10.0 [2018.04.05]
  - Sync with `base-4.11`/GHC 8.4

--- a/base-compat-batteries/src/Data/Monoid/Compat.hs
+++ b/base-compat-batteries/src/Data/Monoid/Compat.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP, NoImplicitPrelude, PackageImports #-}
 module Data.Monoid.Compat (
   module Base
+, (<>)
 ) where
 
-import "base-compat" Data.Monoid.Compat as Base
+import "base-compat" Data.Monoid.Compat as Base hiding ((<>))
+import Data.Semigroup ((<>))

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,5 +1,6 @@
 ## Changes in 0.10.1 [2018.04.xx]
-- Add `Data.List.NonEmpty.Compat`
+- Add `Data.List.NonEmpty.Compat`.
+- Reexport `(Data.Semigroup.<>)` from `Data.Monoid.Compat` back to `base-4.9`.
 
 ## Changes in 0.10.0 [2018.04.05]
  - Sync with `base-4.11`/GHC 8.4

--- a/base-compat/src/Data/Monoid/Compat.hs
+++ b/base-compat/src/Data/Monoid/Compat.hs
@@ -5,8 +5,14 @@ module Data.Monoid.Compat (
 ) where
 
 import Data.Monoid as Base
+#if MIN_VERSION_base(4,9,0)
+  hiding ((<>))
+#endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup ((<>))
+#endif
 
-#if !(MIN_VERSION_base(4,5,0))
+#if !(MIN_VERSION_base(4,5,0)) && !(MIN_VERSION_base(4,9,0))
 
 infixr 6 <>
 

--- a/check/check-hs/Data.Monoid.Compat.check.hs
+++ b/check/check-hs/Data.Monoid.Compat.check.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE NoImplicitPrelude, PackageImports #-}
+module Test where
+import "base-compat-batteries" Data.Monoid.Compat

--- a/check/index/Data.Monoid.Compat.index
+++ b/check/index/Data.Monoid.Compat.index
@@ -1,13 +1,11 @@
 (<>)
 All
-Alt
 Any
 appEndo
 Dual
 Endo
 First
 getAll
-getAlt
 getAny
 getDual
 getFirst

--- a/check/index/Data.Monoid.Compat.index
+++ b/check/index/Data.Monoid.Compat.index
@@ -1,0 +1,32 @@
+(<>)
+All
+Alt
+Any
+appEndo
+Dual
+Endo
+First
+getAll
+getAlt
+getAny
+getDual
+getFirst
+getLast
+getProduct
+getSum
+-- imported via Data.Monoid.Compat
+Last
+mappend
+mconcat
+mempty
+newtype All = ...
+newtype Alt (f
+newtype Any = ...
+newtype Dual a = ...
+newtype Endo a = ...
+newtype First a = ...
+newtype Last a = ...
+newtype Product a = ...
+newtype Sum a = ...
+Product
+Sum

--- a/check/mk-index.sh
+++ b/check/mk-index.sh
@@ -7,4 +7,5 @@ runhaskell dumpindex.hs Control.Monad.Compat | sort > index/Control.Monad.Compat
 runhaskell dumpindex.hs Data.Complex.Compat  | sort > index/Data.Complex.Compat.index
 runhaskell dumpindex.hs Data.Foldable.Compat | sort > index/Data.Foldable.Compat.index
 runhaskell dumpindex.hs Data.List.Compat     | sort > index/Data.List.Compat.index
+runhaskell dumpindex.hs Data.Monoid.Compat   | sort > index/Data.Monoid.Compat.index
 runhaskell dumpindex.hs Data.Ratio.Compat    | sort > index/Data.Ratio.Compat.index

--- a/check/types/Data.Monoid.Compat.types
+++ b/check/types/Data.Monoid.Compat.types
@@ -1,13 +1,11 @@
 (<>) :: Data.Semigroup.Semigroup a => a -> a -> a
 All :: GHC.Types.Bool -> All
-Alt :: f a -> Alt f a
 Any :: GHC.Types.Bool -> Any
 appEndo :: Endo a -> a -> a
 Dual :: a -> Dual a
 Endo :: (a -> a) -> Endo a
 First :: GHC.Base.Maybe a -> First a
 getAll :: All -> GHC.Types.Bool
-getAlt :: Alt f a -> f a
 getAny :: Any -> GHC.Types.Bool
 getDual :: Dual a -> a
 getFirst :: First a -> GHC.Base.Maybe a

--- a/check/types/Data.Monoid.Compat.types
+++ b/check/types/Data.Monoid.Compat.types
@@ -1,0 +1,22 @@
+(<>) :: GHC.Base.Semigroup a => a -> a -> a
+All :: GHC.Types.Bool -> All
+Alt :: f a -> Alt f a
+Any :: GHC.Types.Bool -> Any
+appEndo :: Endo a -> a -> a
+Dual :: a -> Dual a
+Endo :: (a -> a) -> Endo a
+First :: GHC.Base.Maybe a -> First a
+getAll :: All -> GHC.Types.Bool
+getAlt :: Alt f a -> f a
+getAny :: Any -> GHC.Types.Bool
+getDual :: Dual a -> a
+getFirst :: First a -> GHC.Base.Maybe a
+getLast :: Last a -> GHC.Base.Maybe a
+getProduct :: Product a -> a
+getSum :: Sum a -> a
+Last :: GHC.Base.Maybe a -> Last a
+mappend :: Monoid a => a -> a -> a
+mconcat :: Monoid a => [a] -> a
+mempty :: Monoid a => a
+Product :: a -> Product a
+Sum :: a -> Sum a

--- a/check/types/Data.Monoid.Compat.types
+++ b/check/types/Data.Monoid.Compat.types
@@ -1,4 +1,4 @@
-(<>) :: GHC.Base.Semigroup a => a -> a -> a
+(<>) :: Data.Semigroup.Semigroup a => a -> a -> a
 All :: GHC.Types.Bool -> All
 Alt :: f a -> Alt f a
 Any :: GHC.Types.Bool -> Any


### PR DESCRIPTION
Fixes #50.