### PR TITLE
Updates for GHC 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,9 @@ matrix:
     - env: CABALVER=2.2 GHCVER=8.4.3
       compiler: ": #GHC 8.4.3"
       addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=8.6.1 CABALFLAGS=--allow-newer
+      compiler: ": #GHC 8.6.1"
+      addons: {apt: {packages: [cabal-install-head,ghc-8.6.1], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head CABALFLAGS=--allow-newer
       compiler: ": #GHC head"
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
@@ -97,6 +100,7 @@ matrix:
     - env: CABALVER=1.24 GHCVER=7.0.2
     - env: CABALVER=1.24 GHCVER=7.0.3
     - env: CABALVER=1.24 GHCVER=7.2.1
+    - env: CABALVER=head GHCVER=8.6.1 CABALFLAGS=--allow-newer
     - env: CABALVER=head GHCVER=head CABALFLAGS=--allow-newer
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,7 @@ script:
      cd ..;
 
      cd check/;
-     wget https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.2/typediff;
+     wget https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.3/typediff;
      chmod +x typediff;
      cabal configure ${TEST} -v2 ${CABALFLAGS};
      cabal build;

--- a/base-compat-batteries/CHANGES.markdown
+++ b/base-compat-batteries/CHANGES.markdown
@@ -1,7 +1,16 @@
+## Changes in next [????.??.??]
+ - Sync with `base-4.12`/GHC 8.6
+ - Introduce the `Data.Functor.Contravariant.Compat` module, which
+   reexports `Data.Functor.Contravariant` from `base` (if using GHC 8.6 or
+   later) or the `contravariant` library (if using an earlier version of GHC).
+ - This coincides with the `base-compat-???` release. Refer to the
+   [`base-compat` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat/CHANGES.markdown#changes-in-????-????????)
+   for more details.
+
 ## Changes in 0.10.1 [2018.04.10]
-- Add `Data.List.NonEmpty.Compat`.
-- Reexport `(Data.Semigroup.<>)` from `Data.Monoid.Compat`.
-- Tighten lower bounds of compat package dependencies.
+ - Add `Data.List.NonEmpty.Compat`.
+ - Reexport `(Data.Semigroup.<>)` from `Data.Monoid.Compat`.
+ - Tighten lower bounds of compat package dependencies.
  - This coincides with the `base-compat-0.10.1` release. Refer to the
    [`base-compat` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat/CHANGES.markdown#changes-in-0101-20180410)
    for more details.

--- a/base-compat-batteries/base-compat-batteries.cabal
+++ b/base-compat-batteries/base-compat-batteries.cabal
@@ -43,6 +43,7 @@ tested-with:        GHC == 7.0.1,  GHC == 7.0.2,  GHC == 7.0.3,  GHC == 7.0.4
                   , GHC == 8.0.1,  GHC == 8.0.2
                   , GHC == 8.2.1,  GHC == 8.2.2
                   , GHC == 8.4.1,  GHC == 8.4.2,  GHC == 8.4.3
+                  , GHC == 8.6.1
 extra-source-files: CHANGES.markdown, README.markdown
 
 source-repository head
@@ -55,7 +56,7 @@ library
       -Wall
   build-depends:
       base        >= 4.3    && < 5,
-      base-compat >= 0.10.1 && < 0.11
+      base-compat == 0.10.1
   if !impl(ghc >= 7.8)
     build-depends:
       tagged >= 0.8.5 && < 0.9
@@ -72,6 +73,9 @@ library
   if !impl(ghc >= 8.2)
     build-depends:
       bifunctors >= 5.5.2 && < 5.6
+  if !impl(ghc >= 8.6)
+    build-depends:
+      contravariant >= 1.5 && < 1.6
   ghc-options:
       -fno-warn-duplicate-exports
 
@@ -81,6 +85,7 @@ library
   exposed-modules:
       Control.Concurrent.Compat
       Control.Concurrent.MVar.Compat
+      Control.Exception.Compat
       Control.Monad.Compat
       Control.Monad.Fail.Compat
       Control.Monad.IO.Class.Compat
@@ -98,6 +103,7 @@ library
       Data.Functor.Compat
       Data.Functor.Compose.Compat
       Data.Functor.Const.Compat
+      Data.Functor.Contravariant.Compat
       Data.Functor.Identity.Compat
       Data.Functor.Product.Compat
       Data.Functor.Sum.Compat
@@ -136,6 +142,7 @@ library
 
       Control.Concurrent.Compat.Repl.Batteries
       Control.Concurrent.MVar.Compat.Repl.Batteries
+      Control.Exception.Compat.Repl.Batteries
       Control.Monad.Compat.Repl.Batteries
       Control.Monad.Fail.Compat.Repl.Batteries
       Control.Monad.IO.Class.Compat.Repl.Batteries
@@ -154,6 +161,7 @@ library
       Data.Functor.Compose.Compat.Repl.Batteries
       Data.Functor.Const.Compat.Repl.Batteries
       Data.Functor.Identity.Compat.Repl.Batteries
+      Data.Functor.Contravariant.Compat.Repl.Batteries
       Data.Functor.Product.Compat.Repl.Batteries
       Data.Functor.Sum.Compat.Repl.Batteries
       Data.IORef.Compat.Repl.Batteries

--- a/base-compat-batteries/src/Control/Exception/Compat.hs
+++ b/base-compat-batteries/src/Control/Exception/Compat.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE CPP, NoImplicitPrelude, PackageImports #-}
+module Control.Exception.Compat (
+  module Base
+) where
+
+import "base-compat" Control.Exception.Compat as Base

--- a/base-compat-batteries/src/Control/Exception/Compat/Repl/Batteries.hs
+++ b/base-compat-batteries/src/Control/Exception/Compat/Repl/Batteries.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-exports -fno-warn-unused-imports #-}
+-- | Reexports "Control.Exception.Compat"
+-- from a globally unique namespace.
+module Control.Exception.Compat.Repl.Batteries (
+  module Control.Exception.Compat
+) where
+import "this" Control.Exception.Compat

--- a/base-compat-batteries/src/Data/Functor/Contravariant/Compat.hs
+++ b/base-compat-batteries/src/Data/Functor/Contravariant/Compat.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE CPP, NoImplicitPrelude, PackageImports #-}
+module Data.Functor.Contravariant.Compat (
+  module Base
+  ) where
+
+#if MIN_VERSION_base(4,12,0)
+import "base-compat" Data.Functor.Contravariant.Compat as Base
+#else
+import "contravariant" Data.Functor.Contravariant as Base
+#endif

--- a/base-compat-batteries/src/Data/Functor/Contravariant/Compat/Repl/Batteries.hs
+++ b/base-compat-batteries/src/Data/Functor/Contravariant/Compat/Repl/Batteries.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-exports -fno-warn-unused-imports #-}
+-- | Reexports "Data.Functor.Contravariant.Compat"
+-- from a globally unique namespace.
+module Data.Functor.Contravariant.Compat.Repl.Batteries (
+  module Data.Functor.Contravariant.Compat
+) where
+import "this" Data.Functor.Contravariant.Compat

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,6 +1,17 @@
+## Changes in next [????.??.??]
+ - Sync with `base-4.12`/GHC 8.6
+ - Backport `RuntimeRep`-polymorphic versions of `($!)` and `throw` to
+   `Prelude.Compat` and `Control.Exception.Compat`, respectively
+   (if using `base-4.10`/GHC 8.2 or later).
+ - Introduce the `Data.Functor.Contravariant.Compat` module, which reexports
+   `Data.Functor.Contravariant` if using `base-4.12`/GHC 8.6 or later.
+
+   See `Data.Functor.Contravariant.Compat` in the corresponding
+   `base-compat-batteries` release for a version with a wider support window.
+
 ## Changes in 0.10.1 [2018.04.10]
-- Add `Data.List.NonEmpty.Compat`.
-- Reexport `(Data.Semigroup.<>)` from `Data.Monoid.Compat` back to `base-4.9`.
+ - Add `Data.List.NonEmpty.Compat`.
+ - Reexport `(Data.Semigroup.<>)` from `Data.Monoid.Compat` back to `base-4.9`.
 
 ## Changes in 0.10.0 [2018.04.05]
  - Sync with `base-4.11`/GHC 8.4

--- a/base-compat/README.markdown
+++ b/base-compat/README.markdown
@@ -148,6 +148,8 @@ So far the following is covered.
  * `showFFloatAlt` and `showGFloatAlt` to `Numeric.Compat`
  * `lookupEnv`, `setEnv` and `unsetEnv` to `System.Environment.Compat`
  * `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
+ * `RuntimeRep`-polymorphic `($!)` to `Prelude.Compat`
+ * `RuntimeRep`-polymorphic `throw` to `Control.Exception.Compat`
 
 ## What is not covered
 
@@ -258,6 +260,9 @@ on, paired with the things that each library backports:
   * The [`Bifoldable`](http://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Bifoldable.html#t:Bifoldable)
     and [`Bitraversable`](http://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Bitraversable.html#t:Bitraversable)
     type classes, introduced in `base-4.10.0.0`
+* [`contravariant`](http://hackage.haskell.org/package/contravariant)
+  for the [`Contravariant`](http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Functor-Contravariant.html#t:Contravariant)
+  type class, introduced in `base-4.12.0.0`.
 * [`fail`](http://hackage.haskell.org/package/fail)
   for the [`MonadFail`](http://hackage.haskell.org/package/base-4.9.0.0/docs/Control-Monad-Fail.html#t:MonadFail)
   type class, introduced in `base-4.9.0.0`
@@ -297,6 +302,7 @@ on, paired with the things that each library backports:
 
 ## Supported versions of GHC/`base`
 
+ * `ghc-8.6.1`  / `base-4.12.0.0`
  * `ghc-8.4.3`  / `base-4.11.1.0`
  * `ghc-8.4.2`  / `base-4.11.1.0`
  * `ghc-8.4.1`  / `base-4.11.0.0`

--- a/base-compat/base-compat.cabal
+++ b/base-compat/base-compat.cabal
@@ -52,6 +52,7 @@ tested-with:        GHC == 7.0.1,  GHC == 7.0.2,  GHC == 7.0.3,  GHC == 7.0.4
                   , GHC == 8.0.1,  GHC == 8.0.2
                   , GHC == 8.2.1,  GHC == 8.2.2
                   , GHC == 8.4.1,  GHC == 8.4.2,  GHC == 8.4.3
+                  , GHC == 8.6.1
 extra-source-files: CHANGES.markdown, README.markdown
 
 source-repository head
@@ -75,6 +76,7 @@ library
   exposed-modules:
       Control.Concurrent.Compat
       Control.Concurrent.MVar.Compat
+      Control.Exception.Compat
       Control.Monad.Compat
       Control.Monad.Fail.Compat
       Control.Monad.IO.Class.Compat
@@ -92,6 +94,7 @@ library
       Data.Functor.Compat
       Data.Functor.Compose.Compat
       Data.Functor.Const.Compat
+      Data.Functor.Contravariant.Compat
       Data.Functor.Identity.Compat
       Data.Functor.Product.Compat
       Data.Functor.Sum.Compat
@@ -130,6 +133,7 @@ library
 
       Control.Concurrent.Compat.Repl
       Control.Concurrent.MVar.Compat.Repl
+      Control.Exception.Compat.Repl
       Control.Monad.Compat.Repl
       Control.Monad.Fail.Compat.Repl
       Control.Monad.IO.Class.Compat.Repl
@@ -147,6 +151,7 @@ library
       Data.Functor.Compat.Repl
       Data.Functor.Compose.Compat.Repl
       Data.Functor.Const.Compat.Repl
+      Data.Functor.Contravariant.Compat.Repl
       Data.Functor.Identity.Compat.Repl
       Data.Functor.Product.Compat.Repl
       Data.Functor.Sum.Compat.Repl

--- a/base-compat/src/Control/Exception/Compat.hs
+++ b/base-compat/src/Control/Exception/Compat.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+#if MIN_VERSION_base(4,10,0)
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeInType #-}
+#endif
+module Control.Exception.Compat (
+  module Base
+, throw
+) where
+
+import Control.Exception as Base
+#if MIN_VERSION_base(4,10,0) && !(MIN_VERSION_base(4,12,0))
+  hiding (throw)
+import GHC.Exts (RuntimeRep, TYPE, raise#)
+
+-- | Throw an exception.  Exceptions may be thrown from purely
+-- functional code, but may only be caught within the 'IO' monad.
+throw :: forall (r :: RuntimeRep). forall (a :: TYPE r). forall e.
+         Exception e => e -> a
+throw e = raise# (toException e)
+#endif

--- a/base-compat/src/Control/Exception/Compat/Repl.hs
+++ b/base-compat/src/Control/Exception/Compat/Repl.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-exports -fno-warn-unused-imports #-}
+-- | Reexports "Control.Exception.Compat"
+-- from a globally unique namespace.
+module Control.Exception.Compat.Repl (
+  module Control.Exception.Compat
+) where
+import "this" Control.Exception.Compat

--- a/base-compat/src/Data/Functor/Contravariant/Compat.hs
+++ b/base-compat/src/Data/Functor/Contravariant/Compat.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE CPP, NoImplicitPrelude #-}
+module Data.Functor.Contravariant.Compat (
+#if MIN_VERSION_base(4,12,0)
+  module Base
+#endif
+) where
+
+#if MIN_VERSION_base(4,12,0)
+import Data.Functor.Contravariant as Base
+#endif

--- a/base-compat/src/Data/Functor/Contravariant/Compat/Repl.hs
+++ b/base-compat/src/Data/Functor/Contravariant/Compat/Repl.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-exports -fno-warn-unused-imports #-}
+-- | Reexports "Data.Functor.Contravariant.Compat"
+-- from a globally unique namespace.
+module Data.Functor.Contravariant.Compat.Repl (
+  module Data.Functor.Contravariant.Compat
+) where
+import "this" Data.Functor.Contravariant.Compat

--- a/base-compat/src/Prelude/Compat.hs
+++ b/base-compat/src/Prelude/Compat.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP, NoImplicitPrelude #-}
+#if MIN_VERSION_base(4,10,0) && !(MIN_VERSION_base(4,12,0))
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeInType #-}
+#endif
 module Prelude.Compat (
-#if MIN_VERSION_base(4,11,0)
+#if MIN_VERSION_base(4,12,0)
   module Base
 #else
   either
@@ -267,6 +271,9 @@ module Prelude.Compat (
 #if MIN_VERSION_base(4,9,0)
 
 import Prelude as Base
+# if MIN_VERSION_base(4,10,0) && !(MIN_VERSION_base(4,12,0))
+  hiding (($!))
+# endif
 
 #else
 
@@ -311,6 +318,10 @@ import Data.Word
 import Data.Semigroup as Base (Semigroup((<>)))
 #endif
 
+#if MIN_VERSION_base(4,10,0) && !(MIN_VERSION_base(4,12,0))
+import GHC.Exts (TYPE)
+#endif
+
 #if !(MIN_VERSION_base(4,9,0))
 -- | A variant of 'error' that does not produce a stack trace.
 --
@@ -318,4 +329,13 @@ import Data.Semigroup as Base (Semigroup((<>)))
 errorWithoutStackTrace :: [Char] -> a
 errorWithoutStackTrace s = error s
 {-# NOINLINE errorWithoutStackTrace #-}
+#endif
+
+#if MIN_VERSION_base(4,10,0) && !(MIN_VERSION_base(4,12,0))
+-- | Strict (call-by-value) application operator. It takes a function and an
+-- argument, evaluates the argument to weak head normal form (WHNF), then calls
+-- the function with that value.
+
+($!) :: forall r a (b :: TYPE r). (a -> b) -> a -> b
+f $! x = let !vx = x in f vx  -- see #2273
 #endif


### PR DESCRIPTION
Checks off the `base-4.12.0.0` boxes in #24.