### PR TITLE
Support GHC 8.8

### DIFF
--- a/base-compat-batteries/base-compat-batteries.cabal
+++ b/base-compat-batteries/base-compat-batteries.cabal
@@ -67,7 +67,7 @@ library
   if !impl(ghc >= 8.0)
     build-depends:
       fail                >= 4.9.0.0 && < 4.10,
-      semigroups          >= 0.18.4  && < 0.19,
+      semigroups          >= 0.18.4  && < 0.20,
       transformers        >= 0.2     && < 0.6,
       transformers-compat >= 0.6     && < 0.7
   if !impl(ghc >= 8.2)


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.