### PR TITLE
Match `Data.Tuple` API in `base-4.18`

### DIFF
--- a/base-compat-batteries/CHANGES.markdown
+++ b/base-compat-batteries/CHANGES.markdown
@@ -1,3 +1,11 @@
+## Changes in 0.13.0 [????.??.??]
+ - This coincides with the `base-compat-0.13.0` release. Refer to the
+   [`base-compat` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat/CHANGES.markdown#changes-in-0130-????????)
+   for more details.
+ - Require `OneTuple-0.4` or later on GHC 7.4+, as that is the first `OneTuple`
+   release to backport the `MkSolo` data constuctor for `Solo`. See
+   `Data.Tuple.Compat`.
+
 ## Changes in 0.12.2 [2022.08.11]
  - This coincides with the `base-compat-0.12.2` release. Refer to the
    [`base-compat` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat/CHANGES.markdown#changes-in-0122-20220811)

--- a/base-compat-batteries/base-compat-batteries.cabal
+++ b/base-compat-batteries/base-compat-batteries.cabal
@@ -1,5 +1,5 @@
 name:             base-compat-batteries
-version:          0.12.2
+version:          0.13.0
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2018 Simon Hengel,
@@ -48,7 +48,7 @@ library
       Haskell2010
   build-depends:
       base        >= 4.3 && < 5,
-      base-compat == 0.12.2,
+      base-compat == 0.13.0,
       ghc-prim
   if !impl(ghc >= 7.8)
     build-depends:
@@ -70,9 +70,9 @@ library
   if !impl(ghc >= 8.6)
     build-depends:
       contravariant >= 1.5 && < 1.6
-  if !impl(ghc >= 9.0)
+  if !impl(ghc >= 9.6)
     build-depends:
-      OneTuple >= 0.3 && < 0.4
+      OneTuple >= 0.4 && < 0.5
   ghc-options:
       -fno-warn-duplicate-exports
   if impl(ghc >= 7.10)

--- a/base-compat-batteries/src/Data/Tuple/Compat.hs
+++ b/base-compat-batteries/src/Data/Tuple/Compat.hs
@@ -1,6 +1,27 @@
 {-# LANGUAGE CPP, NoImplicitPrelude, PackageImports #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE PatternSynonyms #-}
+#endif
+-- | This uses the @OneTuple@ compatibility library to backport 'Solo' to old
+-- versions of GHC. Note that @OneTuple@ makes use of pattern synonyms, which
+-- cannot be defined on pre-7.8 versions of GHC. As such, it is not feasible
+-- to backport the @Solo@ data constructor on pre-7.8 versions of GHC, as
+-- @OneTuple@ defines this as a pattern synonym.
 module Data.Tuple.Compat
-  ( Solo (..)
+  (
+#if MIN_VERSION_ghc_prim(0,10,0)
+    Solo(MkSolo, Solo)
+#elif MIN_VERSION_ghc_prim(0,7,0)
+    Solo(Solo)
+  , pattern MkSolo
+#elif __GLASGOW_HASKELL__ >= 800
+    Solo(MkSolo, Solo)
+#elif __GLASGOW_HASKELL__ >= 708
+    Solo(MkSolo)
+  , pattern Solo
+#else
+    Solo(MkSolo)
+#endif
   , fst
   , snd
   , curry
@@ -8,9 +29,12 @@ module Data.Tuple.Compat
   , swap
   ) where
 
-#if MIN_VERSION_ghc_prim(0,7,0)
+#if MIN_VERSION_ghc_prim(0,10,0)
 import "base-compat" Data.Tuple.Compat
+#elif MIN_VERSION_ghc_prim(0,7,0)
+import "base-compat" Data.Tuple.Compat
+import "OneTuple" Data.Tuple.Solo (pattern MkSolo)
 #else
 import "base" Data.Tuple
-import "OneTuple" Data.Tuple.Solo (Solo(..))
+import "OneTuple" Data.Tuple.Solo
 #endif

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,3 +1,12 @@
+## Changes in 0.13.0 [????.??.??]
+ - Sync with `base-4.18`/GHC 9.6
+ - `Data.Tuple.Compat`'s `Solo` API now matches what is present in `Data.Tuple`
+   in `base-4.18`. In particular, we now re-export both the `MkSolo` and `Solo`
+   data constructors when building with `ghc-prim-0.10.0` or later, with
+   `MkSolo` being preferred over `Solo`. If you want to backport `MkSolo` to
+   earlier versions of GHC, import `Data.Tuple.Compat` from
+   `base-compat-batteries` instead.
+
 ## Changes in 0.12.2 [2022.08.11]
  - Sync with `base-4.17`/GHC 9.4
  - Backport `(.^.)`, `(.>>.)`, `(.<<.)`, `(!>>.)`, `(!<<.)`, `oneBits` to

--- a/base-compat/base-compat.cabal
+++ b/base-compat/base-compat.cabal
@@ -1,5 +1,5 @@
 name:             base-compat
-version:          0.12.2
+version:          0.13.0
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2018 Simon Hengel,

--- a/base-compat/src/Data/Tuple/Compat.hs
+++ b/base-compat/src/Data/Tuple/Compat.hs
@@ -2,14 +2,23 @@
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
 #endif
+#if MIN_VERSION_ghc_prim(0,7,0)
+{-# LANGUAGE PatternSynonyms #-}
+#endif
+-- | Note that we only re-export @MkSolo@ when building with @ghc-prim-0.10.0@
+-- (bundled with GHC 9.6) or later. If you want to backport @MkSolo@ to older
+-- versions of GHC, import @Data.Tuple.Compat@ from @base-compat-batteries@
+-- instead.
 module Data.Tuple.Compat
   ( fst
   , snd
   , curry
   , uncurry
   , swap
-#if MIN_VERSION_ghc_prim(0,7,0)
-  , Solo(..)
+#if MIN_VERSION_ghc_prim(0,10,0)
+  , Solo(MkSolo,Solo)
+#elif MIN_VERSION_ghc_prim(0,7,0)
+  , Solo(Solo)
 #endif
   ) where
 


### PR DESCRIPTION
In `base-4.18`, `Data.Tuple` exports both the `MkSolo` data constructor as well as the `Solo` pattern synonym, the latter being offered for backwards compatibility. This matches the changes on the `base-compat` and `base-compat-batteries` side.  Note that `base-compat-batteries` now requires `OneTuple-0.4` or later, as that is the first `OneTuple` release to offer `MkSolo`.