### PR TITLE
`base-compat-batteries-0.12.*`: Allow building with `OneTuple-0.4.*`

### DIFF
--- a/base-compat-batteries/CHANGES.markdown
+++ b/base-compat-batteries/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in 0.12.3 [????.??.??]
+ - Allow building with `OneTuple-0.4.*`.
+
 ## Changes in 0.12.2 [2022.08.11]
  - This coincides with the `base-compat-0.12.2` release. Refer to the
    [`base-compat` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat/CHANGES.markdown#changes-in-0122-20220811)

--- a/base-compat-batteries/base-compat-batteries.cabal
+++ b/base-compat-batteries/base-compat-batteries.cabal
@@ -1,5 +1,5 @@
 name:             base-compat-batteries
-version:          0.12.2
+version:          0.12.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2018 Simon Hengel,
@@ -64,7 +64,7 @@ library
       Haskell2010
   build-depends:
       base        >= 4.3 && < 5,
-      base-compat == 0.12.2,
+      base-compat == 0.12.3,
       ghc-prim
   if !impl(ghc >= 7.8)
     build-depends:
@@ -88,7 +88,17 @@ library
       contravariant >= 1.5 && < 1.6
   if !impl(ghc >= 9.0)
     build-depends:
-      OneTuple >= 0.3 && < 0.4
+      OneTuple >= 0.3 && < 0.5
+
+    -- We want to consistently use `Solo` as the name of the data constructor
+    -- for the base-compat-0.12.* series when building with a pre-9.6 version
+    -- of GHC. This is only possible on pre-7.8 versions of GHC (which do not
+    -- support pattern synonyms) with OneTuple-0.3.*, which defines a `Solo`
+    -- data constructor. (In OneTuple-0.4.* and later, the data constructor is
+    -- instead named `MkSolo`.)
+    if !impl(ghc >= 7.8)
+      build-depends:
+        OneTuple == 0.3.*
   ghc-options:
       -fno-warn-duplicate-exports
   if impl(ghc >= 7.10)
@@ -256,6 +266,7 @@ test-suite spec
       -- Other tests
       SafeHaskellSpec
       TestHspecTrustworthy
+      T91Spec
   build-depends:
       base >= 4.3 && < 5
     , base-compat-batteries

--- a/base-compat-batteries/src/Data/Tuple/Compat.hs
+++ b/base-compat-batteries/src/Data/Tuple/Compat.hs
@@ -1,6 +1,23 @@
 {-# LANGUAGE CPP, NoImplicitPrelude, PackageImports #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE PatternSynonyms #-}
+#endif
 module Data.Tuple.Compat
-  ( Solo (..)
+  (
+#if MIN_VERSION_ghc_prim(0,10,0)
+    Solo(MkSolo, Solo)
+#elif __GLASGOW_HASKELL__ >= 708 && \
+      __GLASGOW_HASKELL__ < 800 && \
+      defined(MIN_VERSION_OneTuple)
+# if MIN_VERSION_OneTuple(0,4,0)
+    Solo
+  , pattern Solo
+# else
+    Solo(Solo)
+# endif
+#else
+    Solo(Solo)
+#endif
   , fst
   , snd
   , curry
@@ -12,5 +29,5 @@ module Data.Tuple.Compat
 import "base-compat" Data.Tuple.Compat
 #else
 import "base" Data.Tuple
-import "OneTuple" Data.Tuple.Solo (Solo(..))
+import "OneTuple" Data.Tuple.Solo
 #endif

--- a/base-compat-batteries/test/T91Spec.hs
+++ b/base-compat-batteries/test/T91Spec.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+-- | A regression test for https://github.com/haskell-compat/base-compat/issues/91.
+module T91Spec (main, spec) where
+
+import Data.Tuple.Compat
+import Test.Hspec (Expectation, Spec, describe, hspec, it)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "Solo data constructor" $
+    it "is always available" $ do
+      Solo () `seq` return () :: Expectation

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,3 +1,8 @@
+## Changes in 0.12.3 [????.??.??]
+ - This coincides with the `base-compat-batteries-0.12.3` release. Refer to the
+   [`base-compat-batteries` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat-batteries/CHANGES.markdown#changes-in-0123-????????)
+   for more details.
+
 ## Changes in 0.12.2 [2022.08.11]
  - Sync with `base-4.17`/GHC 9.4
  - Backport `(.^.)`, `(.>>.)`, `(.<<.)`, `(!>>.)`, `(!<<.)`, `oneBits` to

--- a/base-compat/base-compat.cabal
+++ b/base-compat/base-compat.cabal
@@ -1,5 +1,5 @@
 name:             base-compat
-version:          0.12.2
+version:          0.12.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2018 Simon Hengel,

--- a/base-compat/src/Data/Tuple/Compat.hs
+++ b/base-compat/src/Data/Tuple/Compat.hs
@@ -8,8 +8,10 @@ module Data.Tuple.Compat
   , curry
   , uncurry
   , swap
-#if MIN_VERSION_ghc_prim(0,7,0)
-  , Solo(..)
+#if MIN_VERSION_ghc_prim(0,10,0)
+  , Solo(MkSolo, Solo)
+#elif MIN_VERSION_ghc_prim(0,7,0)
+  , Solo(Solo)
 #endif
   ) where
 


### PR DESCRIPTION
We make an effort to ensure some degree of API consistency regardless of which GHC version is used to build the library. In particular, the `base-compat-batteries-0.12.*` has implicitly chose the convention of using `Solo` as the name of the data constructor, so we attempt to preserve this convention. We make an exception for GHC 9.6 (where both `MkSolo` and `Solo` are available).

Fixes #91.