### PR TITLE
Backport functions introduced in `base-4.20`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -243,7 +243,7 @@ jobs:
       - name: install typediff
         run: |
           mkdir -p $HOME/.local/bin
-          curl -L https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.5/typediff > $HOME/.local/bin/typediff
+          curl -L https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.6/typediff > $HOME/.local/bin/typediff
           chmod a+x $HOME/.local/bin/typediff
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20231010
+# version: 0.19.20240416
 #
-# REGENDATA ("0.17.20231010",["github","cabal.project"])
+# REGENDATA ("0.19.20240416",["github","cabal.project"])
 #
 # This file is patched to install the typediff utility from its repository
 # (see github.yml.patch).
@@ -31,24 +31,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.10.0.20240413
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.10.0.20240413
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.4.8
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -124,18 +129,20 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -157,20 +164,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
             echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91000)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -199,6 +206,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -267,6 +286,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(base-compat|base-compat-batteries|type-check)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/base-compat-batteries/CHANGES.markdown
+++ b/base-compat-batteries/CHANGES.markdown
@@ -1,3 +1,8 @@
+## Changes in ???? [????.??.??]
+ - This coincides with the `base-compat-batteries-????` release. Refer to the
+   [`base-compat-batteries` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat-batteries/CHANGES.markdown#changes-in-????-????????)
+   for more details.
+
 ## Changes in 0.13.1 [2023.10.11]
  - This coincides with the `base-compat-batteries-0.13.1` release. Refer to the
    [`base-compat-batteries` changelog](https://github.com/haskell-compat/base-compat/blob/master/base-compat-batteries/CHANGES.markdown#changes-in-0131-20231011)

--- a/base-compat-batteries/base-compat-batteries.cabal
+++ b/base-compat-batteries/base-compat-batteries.cabal
@@ -48,10 +48,11 @@ tested-with:        GHC == 7.0.4
                   , GHC == 8.8.4
                   , GHC == 8.10.7
                   , GHC == 9.0.2
-                  , GHC == 9.2.7
-                  , GHC == 9.4.5
-                  , GHC == 9.6.2
-                  , GHC == 9.8.1
+                  , GHC == 9.2.8
+                  , GHC == 9.4.8
+                  , GHC == 9.6.5
+                  , GHC == 9.8.2
+                  , GHC == 9.10.1
 
 source-repository head
   type: git

--- a/base-compat-batteries/base-compat-batteries.cabal
+++ b/base-compat-batteries/base-compat-batteries.cabal
@@ -1,5 +1,5 @@
 name:             base-compat-batteries
-version:          0.13.1
+version:          0.14.0
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2018 Simon Hengel,
@@ -66,7 +66,7 @@ library
       Haskell2010
   build-depends:
       base        >= 4.3 && < 5,
-      base-compat == 0.13.1,
+      base-compat == 0.14.0,
       ghc-prim
   if !impl(ghc >= 7.8)
     build-depends:

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,5 +1,6 @@
-## Changes in ???? [????.??.??]
+## Changes in 0.14.0 [????.??.??]
  - Sync with `base-4.20`/GHC 9.10
+ - Backport `foldl'` to `Prelude.Compat`
 
 ## Changes in 0.13.1 [2023.10.11]
  - Sync with `base-4.19`/GHC 9.8

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -2,6 +2,8 @@
  - Sync with `base-4.20`/GHC 9.10
  - Backport `foldl'` to `Prelude.Compat`
  - Backport `List` to `Data.List.Compat` (when building with GHC 9.6 or later)
+ - Backport `permutations`, `permutations1`, and `sortOn` to
+   `Data.List.NonEmpty.Compat`
 
 ## Changes in 0.13.1 [2023.10.11]
  - Sync with `base-4.19`/GHC 9.8

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -2,8 +2,9 @@
  - Sync with `base-4.20`/GHC 9.10
  - Backport `foldl'` to `Prelude.Compat`
  - Backport `List` to `Data.List.Compat` (when building with GHC 9.6 or later)
- - Backport `permutations`, `permutations1`, and `sortOn` to
-   `Data.List.NonEmpty.Compat`
+ - Backport `append`, `appendList`, `prependList`, `permutations`,
+   `permutations1`, and `sortOn` to `Data.List.NonEmpty.Compat` (when building
+   with GHC 8.0 or later)
 
 ## Changes in 0.13.1 [2023.10.11]
  - Sync with `base-4.19`/GHC 9.8

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in ???? [????.??.??]
+ - Sync with `base-4.20`/GHC 9.10
+
 ## Changes in 0.13.1 [2023.10.11]
  - Sync with `base-4.19`/GHC 9.8
  - Backport `unzip` to `Data.Functor.Compat`

--- a/base-compat/CHANGES.markdown
+++ b/base-compat/CHANGES.markdown
@@ -1,6 +1,7 @@
 ## Changes in 0.14.0 [????.??.??]
  - Sync with `base-4.20`/GHC 9.10
  - Backport `foldl'` to `Prelude.Compat`
+ - Backport `List` to `Data.List.Compat` (when building with GHC 9.6 or later)
 
 ## Changes in 0.13.1 [2023.10.11]
  - Sync with `base-4.19`/GHC 9.8

--- a/base-compat/README.markdown
+++ b/base-compat/README.markdown
@@ -345,6 +345,7 @@ with identifiers of the same names in their code.
 
 ## Supported versions of GHC/`base`
 
+ * `ghc-9.10.*`  / `base-4.20.*`
  * `ghc-9.8.*`  / `base-4.19.*`
  * `ghc-9.6.*`  / `base-4.18.*`
  * `ghc-9.4.*`  / `base-4.17.*`

--- a/base-compat/README.markdown
+++ b/base-compat/README.markdown
@@ -152,6 +152,7 @@ So far the following is covered.
  * `unsafeFixIO` and `unsafeDupablePerformIO` to `System.IO.Unsafe.IO`
  * `RuntimeRep`-polymorphic `($!)` to `Prelude.Compat`
  * `liftA2` is re-exported from `Prelude.Compat`
+ * `foldl'` is re-exported from `Prelude.Compat`
  * `RuntimeRep`-polymorphic `throw` to `Control.Exception.Compat`
  * `isResourceVanishedError`, `resourceVanishedErrorType`, and
    `isResourceVanishedErrorType` to `System.IO.Error.Compat`

--- a/base-compat/README.markdown
+++ b/base-compat/README.markdown
@@ -158,6 +158,7 @@ So far the following is covered.
    `isResourceVanishedErrorType` to `System.IO.Error.Compat`
  * `singleton` to `Data.List.Compat` and `Data.List.NonEmpty.Compat`
  * `inits1` and `tails1` to `Data.List.NonEmpty.Compat`
+ * `permutations`, `permutations1`, and `sortOn` to `Data.List.NonEmpty.Compat`
  * `hGetContents'`, `getContents'`, and `readFile'` to `System.IO.Compat`
  * `readBinP` to `Text.Read.Lex.Compat`
  * `withTypeable` and `pattern TypeRep` to `Type.Reflection.Compat`

--- a/base-compat/README.markdown
+++ b/base-compat/README.markdown
@@ -166,6 +166,7 @@ So far the following is covered.
  * `heqT` to `Data.Typeable.Compat`
  * `unzip` to `Data.Functor.Compat`
  * `(!?)` and `unsnoc` to `Data.List.Compat`
+ * `List` to `Data.List.Compat` (when building with GHC 9.6 or later)
  * `getSolo` to `Data.Tuple.Compat`
  * `decT` and `hdecT` to `Data.Typeable.Compat`
  * `decTypeRep` to `Type.Reflection.Compat`

--- a/base-compat/base-compat.cabal
+++ b/base-compat/base-compat.cabal
@@ -57,10 +57,11 @@ tested-with:        GHC == 7.0.4
                   , GHC == 8.8.4
                   , GHC == 8.10.7
                   , GHC == 9.0.2
-                  , GHC == 9.2.7
-                  , GHC == 9.4.5
-                  , GHC == 9.6.2
-                  , GHC == 9.8.1
+                  , GHC == 9.2.8
+                  , GHC == 9.4.8
+                  , GHC == 9.6.5
+                  , GHC == 9.8.2
+                  , GHC == 9.10.1
 
 source-repository head
   type: git

--- a/base-compat/base-compat.cabal
+++ b/base-compat/base-compat.cabal
@@ -1,5 +1,5 @@
 name:             base-compat
-version:          0.13.1
+version:          0.14.0
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2018 Simon Hengel,

--- a/base-compat/src/Data/List/Compat.hs
+++ b/base-compat/src/Data/List/Compat.hs
@@ -5,6 +5,11 @@
 #endif
 module Data.List.Compat (
   module Base
+
+#if MIN_VERSION_base(4,18,0) && !(MIN_VERSION_base(4,20,0))
+, List
+#endif
+
 #if !(MIN_VERSION_base(4,19,0))
 , (!?)
 , unsnoc
@@ -103,6 +108,10 @@ import GHC.Exts (build)
 
 #if !(MIN_VERSION_base(4,19,0))
 import Prelude.Compat hiding (foldr, null)
+#endif
+
+#if MIN_VERSION_base(4,18,0) && !(MIN_VERSION_base(4,20,0))
+import GHC.List (List)
 #endif
 
 #if !(MIN_VERSION_base(4,5,0))

--- a/base-compat/src/Data/List/NonEmpty/Compat.hs
+++ b/base-compat/src/Data/List/NonEmpty/Compat.hs
@@ -27,6 +27,7 @@ module Data.List.NonEmpty.Compat (
   , uncons
   , unfoldr
   , sort
+  , sortOn
   , reverse
   , inits
   , inits1
@@ -60,6 +61,8 @@ module Data.List.NonEmpty.Compat (
   , groupBy1
   , groupWith1
   , groupAllWith1
+  , permutations
+  , permutations1
   -- * Sublist predicates
   , isPrefixOf
   -- * \"Set\" operations
@@ -82,7 +85,7 @@ module Data.List.NonEmpty.Compat (
 #if MIN_VERSION_base(4,9,0)
 import Data.List.NonEmpty
 
-# if !(MIN_VERSION_base(4,18,0))
+# if !(MIN_VERSION_base(4,20,0))
 import qualified Prelude.Compat as Prelude
 import Prelude.Compat ((.))
 
@@ -98,6 +101,43 @@ import qualified Data.List.Compat as List
 -- /Since: 4.15/
 singleton :: a -> NonEmpty a
 singleton a = a :| []
+# endif
+
+# if !(MIN_VERSION_base(4,16,0))
+-- | A monomorphic version of 'Prelude.<>' for 'NonEmpty'.
+--
+-- >>> append (1 :| []) (2 :| [3])
+-- 1 :| [2,3]
+--
+-- /Since: 4.16/
+append :: NonEmpty a -> NonEmpty a -> NonEmpty a
+append = (Prelude.<>)
+
+-- | Attach a list at the end of a 'NonEmpty'.
+--
+-- >>> appendList (1 :| [2,3]) []
+-- 1 :| [2,3]
+--
+-- >>> appendList (1 :| [2,3]) [4,5]
+-- 1 :| [2,3,4,5]
+--
+-- /Since: 4.16/
+appendList :: NonEmpty a -> [a] -> NonEmpty a
+appendList (x :| xs) ys = x :| xs Prelude.<> ys
+
+-- | Attach a list at the beginning of a 'NonEmpty'.
+--
+-- >>> prependList [] (1 :| [2,3])
+-- 1 :| [2,3]
+--
+-- >>> prependList [negate 1, 0] (1 :| [2, 3])
+-- -1 :| [0,1,2,3]
+--
+-- /Since: 4.16/
+prependList :: [a] -> NonEmpty a -> NonEmpty a
+prependList ls ne = case ls of
+  [] -> ne
+  (x : xs) -> x :| xs Prelude.<> toList ne
 # endif
 
 # if !(MIN_VERSION_base(4,18,0))
@@ -138,41 +178,69 @@ tails1 =
   fromList . Prelude.map fromList . List.init . List.tails . Foldable.toList
 # endif
 
-# if !(MIN_VERSION_base(4,16,0))
--- | A monomorphic version of 'Prelude.<>' for 'NonEmpty'.
+# if !(MIN_VERSION_base(4,20,0))
+-- | The 'permutations' function returns the list of all permutations of the argument.
 --
--- >>> append (1 :| []) (2 :| [3])
--- 1 :| [2,3]
---
--- /Since: 4.16/
-append :: NonEmpty a -> NonEmpty a -> NonEmpty a
-append = (Prelude.<>)
+-- /Since: 4.20.0.0/
+permutations            :: [a] -> NonEmpty [a]
+permutations xs0        =  xs0 :| perms xs0 []
+  where
+    perms []     _  = []
+    perms (t:ts) is = List.foldr interleave (perms ts (t:is)) (permutations is)
+      where interleave    xs     r = let (_,zs) = interleave' Prelude.id xs r in zs
+            interleave' _ []     r = (ts, r)
+            interleave' f (y:ys) r = let (us,zs) = interleave' (f . (y:)) ys r
+                                     in  (y:us, f (t:y:us) : zs)
+-- The implementation of 'permutations' is adopted from 'GHC.Internal.Data.List.permutations',
+-- see there for discussion and explanations.
 
--- | Attach a list at the end of a 'NonEmpty'.
+-- | 'permutations1' operates like 'permutations', but uses the knowledge that its input is
+-- non-empty to produce output where every element is non-empty.
 --
--- >>> appendList (1 :| [2,3]) []
--- 1 :| [2,3]
+-- > permutations1 = fmap fromList . permutations . toList
 --
--- >>> appendList (1 :| [2,3]) [4,5]
--- 1 :| [2,3,4,5]
---
--- /Since: 4.16/
-appendList :: NonEmpty a -> [a] -> NonEmpty a
-appendList (x :| xs) ys = x :| xs Prelude.<> ys
+-- /Since: 4.20.0.0/
+permutations1 :: NonEmpty a -> NonEmpty (NonEmpty a)
+permutations1 xs = fromList Prelude.<$> permutations (toList xs)
 
--- | Attach a list at the beginning of a 'NonEmpty'.
+-- | Sort a 'NonEmpty' on a user-supplied projection of its elements.
+-- See 'List.sortOn' for more detailed information.
 --
--- >>> prependList [] (1 :| [2,3])
--- 1 :| [2,3]
+-- ==== __Examples__
 --
--- >>> prependList [negate 1, 0] (1 :| [2, 3])
--- -1 :| [0,1,2,3]
+-- >>> sortOn fst $ (2, "world") :| [(4, "!"), (1, "Hello")]
+-- (1,"Hello") :| [(2,"world"),(4,"!")]
 --
--- /Since: 4.16/
-prependList :: [a] -> NonEmpty a -> NonEmpty a
-prependList ls ne = case ls of
-  [] -> ne
-  (x : xs) -> x :| xs Prelude.<> toList ne
+-- >>> sortOn length $ "jim" :| ["creed", "pam", "michael", "dwight", "kevin"]
+-- "jim" :| ["pam","creed","kevin","dwight","michael"]
+--
+-- ==== __Performance notes__
+--
+-- This function minimises the projections performed, by materialising
+-- the projections in an intermediate list.
+--
+-- For trivial projections, you should prefer using 'sortBy' with
+-- 'comparing', for example:
+--
+-- >>> sortBy (comparing fst) $ (3, 1) :| [(2, 2), (1, 3)]
+-- (1,3) :| [(2,2),(3,1)]
+--
+-- Or, for the exact same API as 'sortOn', you can use `sortBy . comparing`:
+--
+-- >>> (sortBy . comparing) fst $ (3, 1) :| [(2, 2), (1, 3)]
+-- (1,3) :| [(2,2),(3,1)]
+--
+-- 'sortWith' is an alias for `sortBy . comparing`.
+--
+-- /Since: 4.20.0.0/
+sortOn :: Prelude.Ord b => (a -> b) -> NonEmpty a -> NonEmpty a
+sortOn f = lift (List.sortOn f)
+
+-- | Lift list operations to work on a 'NonEmpty' stream.
+--
+-- /Beware/: If the provided function returns an empty list,
+-- this will raise an error.
+lift :: Foldable.Foldable f => ([a] -> [b]) -> f a -> NonEmpty b
+lift f = fromList . f . Foldable.toList
 # endif
-
 #endif

--- a/base-compat/src/Prelude/Compat.hs
+++ b/base-compat/src/Prelude/Compat.hs
@@ -7,11 +7,11 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeInType #-}
 #endif
-#if MIN_VERSION_base(4,17,0) && !(MIN_VERSION_base(4,18,0))
+#if MIN_VERSION_base(4,17,0) && !(MIN_VERSION_base(4,20,0))
 {-# LANGUAGE ExplicitNamespaces #-}
 #endif
 module Prelude.Compat (
-#if MIN_VERSION_base(4,18,0)
+#if MIN_VERSION_base(4,20,0)
   module Base
 #else
   either
@@ -119,6 +119,7 @@ module Prelude.Compat (
 , elem
 , foldMap
 , foldl
+, foldl'
 , foldl1
 , foldr
 , foldr1
@@ -297,6 +298,10 @@ import Prelude as Base hiding (
 
 # if !(MIN_VERSION_base(4,18,0))
 import Control.Applicative (liftA2)
+# endif
+
+# if !(MIN_VERSION_base(4,20,0))
+import Data.Foldable (foldl')
 # endif
 
 #else

--- a/check/type-check.cabal
+++ b/check/type-check.cabal
@@ -69,6 +69,13 @@ executable for-repl
   build-depends:
     base,
     base-compat-batteries
+  if impl(ghc >= 9.10)
+    -- This depends on `ghc-internal` to ensure that GHCi prints things like
+    -- GHC.Internal.Maybe.Maybe rather than
+    -- ghc-internal:GHC.Internal.Maybe.Maybe, the latter of which typediff
+    -- cannot parse.
+    build-depends:
+      ghc-internal
 
 -- Run with
 -- (cd check && cabal new-run dumptypes Control.Monad.Compat)

--- a/check/type-check.cabal
+++ b/check/type-check.cabal
@@ -35,10 +35,11 @@ tested-with:         GHC == 7.0.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.7
-                   , GHC == 9.4.5
-                   , GHC == 9.6.2
-                   , GHC == 9.8.1
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.5
+                   , GHC == 9.8.2
+                   , GHC == 9.10.1
 
 extra-source-files:
   check-hs/*.hs

--- a/github.yml.patch
+++ b/github.yml.patch
@@ -28,7 +28,7 @@ index 417a210..5fa3f49 100644
 +      - name: install typediff
 +        run: |
 +          mkdir -p $HOME/.local/bin
-+          curl -L https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.5/typediff > $HOME/.local/bin/typediff
++          curl -L https://github.com/haskell-compat/base-compat/releases/download/typediff-0.1.6/typediff > $HOME/.local/bin/typediff
 +          chmod a+x $HOME/.local/bin/typediff
        - name: checkout
          uses: actions/checkout@v3


### PR DESCRIPTION
Checks off the `base-4.20.0.0` boxes in https://github.com/haskell-compat/base-compat/issues/24.