### PR TITLE
Remove broken hackage-deps badge

### DIFF
--- a/base-compat-batteries/README.markdown
+++ b/base-compat-batteries/README.markdown
@@ -1,6 +1,5 @@
 # `base-compat` with extra batteries
 [![Hackage](https://img.shields.io/hackage/v/base-compat-batteries.svg)][Hackage: base-compat-batteries]
-[![Hackage Dependencies](https://img.shields.io/hackage-deps/v/base-compat-batteries.svg)](http://packdeps.haskellers.com/reverse/base-compat-batteries)
 [![Haskell Programming Language](https://img.shields.io/badge/language-Haskell-blue.svg)][Haskell.org]
 [![BSD3 License](http://img.shields.io/badge/license-MIT-brightgreen.svg)][tl;dr Legal: MIT]
 

--- a/base-compat/README.markdown
+++ b/base-compat/README.markdown
@@ -1,6 +1,5 @@
 # A compatibility layer for `base`
 [![Hackage](https://img.shields.io/hackage/v/base-compat.svg)][Hackage: base-compat]
-[![Hackage Dependencies](https://img.shields.io/hackage-deps/v/base-compat.svg)](http://packdeps.haskellers.com/reverse/base-compat)
 [![Haskell Programming Language](https://img.shields.io/badge/language-Haskell-blue.svg)][Haskell.org]
 [![BSD3 License](http://img.shields.io/badge/license-MIT-brightgreen.svg)][tl;dr Legal: MIT]
 


### PR DESCRIPTION
It's deprecated for a long time: https://github.com/badges/shields/pull/10618